### PR TITLE
Remove ComplexityMeasures as a dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Jan Swierczek-Jereczek <jan.jereczek@gmail.com>", "George Datseris <
 version = "0.1.0"
 
 [deps]
-ComplexityMeasures = "ab4b797d-85ee-42ba-b621-05d793b346a2"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
@@ -23,6 +22,5 @@ HypothesisTests = "0.11"
 Reexport = "1.2"
 StatsBase = "0.33, 0.34"
 TimeseriesSurrogates = "2"
-ComplexityMeasures = "^2.7"
 FFTW = "^1.6"
 

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 BSplineKit = "093aae92-e908-43d7-9660-e50ee39d5a0a"
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
+ComplexityMeasures = "ab4b797d-85ee-42ba-b621-05d793b346a2"
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
@@ -15,3 +16,4 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 Documenter = "0.27"
+ComplexityMeasures = "^2.7"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -46,19 +46,17 @@ LowfreqPowerSpectrum
 
 ### Nonlinear dynamics
 
-Indicators that come from nonlinear timeseries analysis and quantify some entropy-based dynamic quantity in the timeseries. They are provided by the [ComplexityMeasures.jl](https://juliadynamics.github.io/ComplexityMeasures.jl/stable/) package, that lists 100s of possible such indicators. Here we only provide an indicator out of the box for the permutation entropy, but
-building something similar is trivial:
-```julia
-function permutation_entropy(; m = 3, τ = 1)
-    est = SymbolicPermutation(; m, τ)
-    return x -> entropy_normalized(est, x)
-end
-```
+Indicators that come from nonlinear timeseries analysis typically quantify some entropy-like or complexity measure from the timeseries.
+Thousands (_literally_) such measures are provided out of the box by the [ComplexityMeasures.jl](https://juliadynamics.github.io/DynamicalSystemsDocs.jl/complexitymeasures/stable/) package. Given that any of these may be used as an indicator or change metric, we made the decision to not copy-paste any measure here, as it is easy for the user to use any of them.
 
-```@docs
-permutation_entropy
-entropy
+For example, using the permutation entropy as an indicator is as simple as doing
+```julia
+using ComplexityMeasures
+est = OrdinalPatterns(; m = 3) # order 3
+# create a function that given timeseries returns permutation entropy
+indicator = x -> entropy_normalized(est, x)
 ```
+and giving the created `indicator` to e.g., [`SlidingWindowConfig`](@ref).
 
 ## [Change metrics](@id change_metrics)
 
@@ -80,10 +78,7 @@ difference_of_means
 
 The only difference between what is an "indicator" and what is a "change metric" is purely conceptual. As far as the code base of TransitionsInTimeseries.jl is concerned, they are both functions `f: x::AbstractVector{Real} -> f(x)::Real`. As a user you may give any such function for an indicator or change metric.
 
-There are situations where you may optimize such a function based on knowledge of input `x` type and length.
-
-TODO: Here explain how to use precomputable functions
-
+There are situations where you may optimize such a function based on knowledge of input `x` type and length, in which case you may use `PrecomputableFunction`:
 
 ```@docs
 PrecomputableFunction

--- a/docs/src/examples/logistic.jl
+++ b/docs/src/examples/logistic.jl
@@ -46,12 +46,19 @@ fig
 # ## Using a simpler change metric
 
 # Now, let's compute and various indicators and their changes,
-# focusing on the fourth indicator, the permutation entropy. We use
+# focusing on the permutation entropy as an indicator. We use
 # order 4 here, because we know that to detect changes in a period `m` we would need
 # an order ≥ `m+1` permutation entropy.
 
-using TransitionsInTimeseries
-indicators = (var, ar1_whitenoise, permutation_entropy(m = 4))
+using TransitionsInTimeseries, ComplexityMeasures
+
+function permutation_entropy(m)
+    est = SymbolicPermutation(; m) # order 3
+    indicator = x -> entropy_normalized(est, x)
+    return indicator
+end
+
+indicators = (var, ar1_whitenoise, permutation_entropy(4))
 indistrings = ("var", "ar1", "pe")
 
 # In this example there is no critical slowing down;

--- a/src/TransitionsInTimeseries.jl
+++ b/src/TransitionsInTimeseries.jl
@@ -13,7 +13,6 @@ using Downloads
 using DelimitedFiles
 using InteractiveUtils
 using FFTW
-using ComplexityMeasures
 
 using Reexport
 @reexport using TimeseriesSurrogates

--- a/test/indicators.jl
+++ b/test/indicators.jl
@@ -20,11 +20,3 @@ end
     @test metricc(y_lofreq[1:nt]) > 0.95
     @test metricc(y_hifreq[1:nt]) < 0.05
 end
-
- @testset "perment" begin
-    x = 1:1000
-    pe = permutation_entropy()
-    # Sliding window over this x gives the same entropy values, all of which are zero
-    res = windowmap(pe, x; width = 10)
-    @test res == zeros(length(res))
-end


### PR DESCRIPTION
Instead, outline in the docs how to use the package to make new indicators. We don't need a dependency to just create and re-export one metric...