### PR TITLE
Reducing the memory allocation of the significance testing

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -36,3 +36,37 @@ Output on Jan's machine:
 
 # Check 0 allocations
 @btime inplace_map!(ar1_whitenoise, $var_x, $wv)
+
+
+#################################################
+# surrogates_loop!
+#################################################
+
+using TransitionsInTimeseries
+
+n = 1001
+t = collect(1.0:n)
+x = copy(t)
+
+indicators = (mean, var)
+change_metrics = RidgeRegressionSlope()
+
+config = SlidingWindowConfig(indicators, change_metrics;
+    width_ind = 100, stride_ind = 1,
+    width_cha = 100, stride_cha = 1, whichtime = last,
+)
+
+res = estimate_indicator_changes(config, x, t)
+signif = SurrogatesSignificance(n = 100, tail = :both, p = 0.1)
+flags = significant_transitions(res, signif)
+
+@btime estimate_indicator_changes($config, $x, $t)
+# 141.557 μs (4 allocations: 40.56 KiB)
+@btime significant_transitions($res, $signif)
+#=
+Former version of the code: 5.178 ms (1954 allocations: 3.03 MiB)
+Current version of the code: 4.863 ms (738 allocations: 2.96 MiB)
+
+Although there is an improvement in the number of allocations, the performance
+is not significantly improved.
+=#

--- a/src/significance/surrogates_significance.jl
+++ b/src/significance/surrogates_significance.jl
@@ -187,13 +187,15 @@ end
 function accumulate_pvals!(pval_right, pval_left, tail, c, change_dummy)
     if tail == :both || tail == :right
         pval_right .+= c .< change_dummy
-    elseif tail == :both || tail == :left
+    end
+    if tail == :both || tail == :left
         pval_left .+= c .> change_dummy
     end
 end
 
 function choose_pval!(pval, pval_right, pval_left, tail)
     if tail == :both
+        println(pval_right, pval_left)
         pval .= 2min.(pval_right, pval_left)
     elseif tail == :right
         pval .= pval_right

--- a/src/significance/surrogates_significance.jl
+++ b/src/significance/surrogates_significance.jl
@@ -195,7 +195,6 @@ end
 
 function choose_pval!(pval, pval_right, pval_left, tail)
     if tail == :both
-        println(pval_right, pval_left)
         pval .= 2min.(pval_right, pval_left)
     elseif tail == :right
         pval .= pval_right

--- a/src/significance/surrogates_significance.jl
+++ b/src/significance/surrogates_significance.jl
@@ -145,7 +145,9 @@ function sliding_surrogates_loop!(
         indicator_dummys, change_dummys,
         width_ind, stride_ind, width_cha, stride_cha, tail
     )
-    pval_right, pval_left = init_pvals(pval)
+    pval_right = zeros(length(pval))
+    pval_left = copy(pval_right)
+
     # parallelized surrogate loop
     Threads.@threads for _ in 1:n_surrogates
         id = Threads.threadid()
@@ -164,7 +166,8 @@ function segmented_surrogates_loop!(
     indicator, chametric, c, pval, n_surrogates, sgens,
     indicator_dummys, change_dummys, width_ind, stride_ind, tail
 )
-    pval_right, pval_left = init_pvals(pval)
+    pval_right = zeros(length(pval))
+    pval_left = copy(pval_right)
     # parallelized surrogate loop
     Threads.@threads for _ in 1:n_surrogates
         id = Threads.threadid()
@@ -176,12 +179,6 @@ function segmented_surrogates_loop!(
         accumulate_pvals!(pval_right, pval_left, tail, c, change_dummy)
     end
     choose_pval!(pval, pval_right, pval_left, tail)
-end
-
-function init_pvals(pval)
-    pval_right = zeros(length(pval))
-    pval_left = copy(pval_right)
-    return pval_right, pval_left
 end
 
 function accumulate_pvals!(pval_right, pval_left, tail, c, change_dummy)

--- a/src/significance/surrogates_significance.jl
+++ b/src/significance/surrogates_significance.jl
@@ -145,11 +145,7 @@ function sliding_surrogates_loop!(
         indicator_dummys, change_dummys,
         width_ind, stride_ind, width_cha, stride_cha, tail
     )
-
-    if tail == :both
-        pval_right = zeros(length(pval))
-        pval_left = copy(pval_right)
-    end
+    pval_right, pval_left = init_pvals(pval)
     # parallelized surrogate loop
     Threads.@threads for _ in 1:n_surrogates
         id = Threads.threadid()
@@ -159,30 +155,16 @@ function sliding_surrogates_loop!(
             width = width_ind, stride = stride_ind)
         windowmap!(chametric, change_dummy, indicator_dummys[id];
             width = width_cha, stride = stride_cha)
-        if tail == :right
-            pval .+= c .< change_dummy
-        elseif tail == :left
-            pval .+= c .> change_dummy
-        elseif tail == :both
-            pval_right .+= c .< change_dummy
-            pval_left .+= c .> change_dummy
-        end
+        accumulate_pvals!(pval_right, pval_left, tail, c, change_dummy)
     end
-    if tail == :both
-        pval .= 2min.(pval_right, pval_left)
-    end
+    choose_pval!(pval, pval_right, pval_left, tail)
 end
 
 function segmented_surrogates_loop!(
     indicator, chametric, c, pval, n_surrogates, sgens,
     indicator_dummys, change_dummys, width_ind, stride_ind, tail
 )
-
-    if tail == :both
-        pval_right = zeros(length(pval))
-        pval_left = copy(pval_right)
-    end
-
+    pval_right, pval_left = init_pvals(pval)
     # parallelized surrogate loop
     Threads.@threads for _ in 1:n_surrogates
         id = Threads.threadid()
@@ -191,16 +173,31 @@ function segmented_surrogates_loop!(
         windowmap!(indicator, indicator_dummys[id], s;
             width = width_ind, stride = stride_ind)
         change_dummy = chametric(indicator_dummys[id])
-        if tail == :right
-            pval .+= c .< change_dummy
-        elseif tail == :left
-            pval .+= c .> change_dummy
-        elseif tail == :both
-            pval_right .+= c .< change_dummy
-            pval_left .+= c .> change_dummy
-        end
+        accumulate_pvals!(pval_right, pval_left, tail, c, change_dummy)
     end
+    choose_pval!(pval, pval_right, pval_left, tail)
+end
+
+function init_pvals(pval)
+    pval_right = zeros(length(pval))
+    pval_left = copy(pval_right)
+    return pval_right, pval_left
+end
+
+function accumulate_pvals!(pval_right, pval_left, tail, c, change_dummy)
+    if tail == :both || tail == :right
+        pval_right .+= c .< change_dummy
+    elseif tail == :both || tail == :left
+        pval_left .+= c .> change_dummy
+    end
+end
+
+function choose_pval!(pval, pval_right, pval_left, tail)
     if tail == :both
         pval .= 2min.(pval_right, pval_left)
+    elseif tail == :right
+        pval .= pval_right
+    elseif tail == :left
+        pval .= pval_left
     end
 end


### PR DESCRIPTION
In `sliding_surrogates_loop!` and `segmented_surrogates_loop!`, many allocations were occurring so far. This has been reduced by introducing three new functions `init_pvals`, `accumulate_pvals!` and `choose_pval!`. With them, we now **always** create `pval_right` and `pval_left`, which allows to go from 5.178 ms (1954 allocations: 3.03 MiB) down to 4.989 ms (738 allocations: 2.96 MiB) - c.f. example that has been appended to `benchmark/benchmarks.jl`. These new functions also allow an easier maintenance of `sliding_surrogates_loop!` and `segmented_surrogates_loop!`.

Although there is an improvement in the number of allocations, the performance
is not significantly improved. I find it a bit challenging to understand if we can cut the memory allocation and the runt-time even more. @Datseris, your expertise is mostly welcome on that matter!