### PR TITLE
Swap loops and improve segmented analysis

### DIFF
--- a/benchmark/swapped_loops.jl
+++ b/benchmark/swapped_loops.jl
@@ -1,0 +1,36 @@
+using TransitionsInTimeseries
+
+n = 10_000
+t = 1:n
+x = rand(n)
+indicators = (var, ar1_whitenoise)
+change_metrics = RidgeRegressionSlope()
+config = SlidingWindowConfig(indicators, change_metrics, stride_ind = 2, stride_cha = 10)
+results = estimate_indicator_changes(config, x, t)
+signif = SurrogatesSignificance()
+@btime significant_transitions($results, $signif)
+#=
+New code = swaploops-indicators-surrogates.
+Old code = main branch (2023/10/30).
+
+New code: 2.103 s (60,345 allocations: 1.12 GiB)
+Old code: 2.413 s (80,415 allocations: 2.24 GiB)
+=#
+
+
+
+nseg = 10
+tseg_start = 100 .+ range(0, 0.9 * n, length = nseg)
+tseg_end = 900 .+ range(0, 0.9 * n, length = nseg)
+config = SegmentedWindowConfig(indicators, change_metrics, collect(tseg_start),
+    collect(tseg_end), min_width_cha = 50)
+results = estimate_indicator_changes(config, x, t)
+flags = significant_transitions(results, signif)
+@btime significant_transitions($results, $signif)
+#=
+New code = swaploops-indicators-surrogates.
+Old code = main branch (2023/10/30).
+
+New code: 3.024 s (202,536 allocations: 956.14 MiB)
+Old code: 3.881 s (403,763 allocations: 1.87 GiB)
+=#

--- a/src/analysis/segmented_window.jl
+++ b/src/analysis/segmented_window.jl
@@ -21,7 +21,7 @@ The results output corresponding to `SlidingWindowConfig` is [`SegmentedWindowRe
 - `width_ind::Int=100, stride_ind::Int=1, whichtime = midpoint, T = Float64`: keywords
   identical as in [`SlidingWindowConfig`](@ref).
 - `min_width_cha::Int=typemax(Int)`: minimal width required to perform the change metric estimation.
-  If a segment is not sufficiently long, the change metric is `Inf`.
+  If a segment is not sufficiently long, the change metric is `NaN`.
 """
 struct SegmentedWindowConfig{F, G, W<:Function} <: IndicatorsChangesConfig
     indicators::F
@@ -71,7 +71,7 @@ function estimate_indicator_changes(config::SegmentedWindowConfig, x, t)
     t_indicator = [T[] for _ in eachindex(tseg_start)]
     x_indicator = [X[;;] for _ in eachindex(tseg_start)]
     t_change = T.(config.tseg_end)
-    x_change = fill(X(Inf), length(tseg_start), n_ind)
+    x_change = fill(X(NaN), length(tseg_start), n_ind)
     one2one = length(change_metrics) == length(indicators)
 
     dummy_chametric = map(f -> precompute(f, X.(1:2)), change_metrics)
@@ -84,9 +84,9 @@ function estimate_indicator_changes(config::SegmentedWindowConfig, x, t)
             stride = config.stride_ind)
         len_ind = length(t_indicator[k])
 
-        # Init with Inf instead of 0 to easily recognise when the segment was too short
+        # Init with NaN instead of 0 to easily recognise when the segment was too short
         # for the computation to be performed.
-        x_indicator[k] = fill(X(Inf), len_ind, n_ind)
+        x_indicator[k] = fill(X(NaN), len_ind, n_ind)
 
         # only analyze if segment long enough to compute metrics
         if len_ind > config.min_width_cha

--- a/src/analysis/segmented_window.jl
+++ b/src/analysis/segmented_window.jl
@@ -21,7 +21,7 @@ The results output corresponding to `SlidingWindowConfig` is [`SegmentedWindowRe
 - `width_ind::Int=100, stride_ind::Int=1, whichtime = midpoint, T = Float64`: keywords
   identical as in [`SlidingWindowConfig`](@ref).
 - `min_width_cha::Int=typemax(Int)`: minimal width required to perform the change metric estimation.
-  If a segment is not sufficiently long, the change metric is `NaN`.
+  If a segment is not sufficiently long, the change metric is `Inf`.
 """
 struct SegmentedWindowConfig{F, G, W<:Function} <: IndicatorsChangesConfig
     indicators::F
@@ -46,6 +46,12 @@ function SegmentedWindowConfig(
         throw(ArgumentError("The vectors containing the start and end time of the"*
             " segments must be of equal length."))
     end
+    if length(tseg_start) < 1
+        throw(ArgumentError("SegmentIndexing requires at least one segment."))
+    end
+    if count(tseg_start .>= tseg_end) > 1
+        throw(ArgumentError("End time of segment must be strictly larger than start time."))
+    end
     indicators, change_metrics = sanitycheck_metrics(indicators, change_metrics)
     # Last step: precomputable functions, if any
     indicators = map(f -> precompute(f, 1:T(width_ind)), indicators)
@@ -60,49 +66,54 @@ function estimate_indicator_changes(config::SegmentedWindowConfig, x, t)
     X, T = eltype(x), eltype(t)
     (; indicators, change_metrics, tseg_start, tseg_end) = config
     n_ind = length(indicators)
+    i1, i2 = segment_time(t, tseg_start, tseg_end)
 
     t_indicator = [T[] for _ in eachindex(tseg_start)]
     x_indicator = [X[;;] for _ in eachindex(tseg_start)]
     t_change = T.(config.tseg_end)
-    x_change = fill(Inf, length(tseg_start), n_ind)
+    x_change = fill(X(Inf), length(tseg_start), n_ind)
     one2one = length(change_metrics) == length(indicators)
 
+    dummy_chametric = map(f -> precompute(f, X.(1:2)), change_metrics)
+    precomp_change_metrics = [dummy_chametric for _ in eachindex(i1)]
+
     for k in eachindex(tseg_start)
-        tseg, xseg = segment(t, x, tseg_start[k], tseg_end[k])
+        tseg = view(t, i1[k]:i2[k])
+        xseg = view(x, i1[k]:i2[k])
         t_indicator[k] = windowmap(config.whichtime, tseg; width = config.width_ind,
             stride = config.stride_ind)
         len_ind = length(t_indicator[k])
 
-        # Init with NaN instead of 0 to easily recognise when the segment was too short
+        # Init with Inf instead of 0 to easily recognise when the segment was too short
         # for the computation to be performed.
-        x_indicator[k] = fill(NaN, len_ind, n_ind)
+        x_indicator[k] = fill(X(Inf), len_ind, n_ind)
 
         # only analyze if segment long enough to compute metrics
         if len_ind > config.min_width_cha
+            precomp_change_metrics[k] = map(f -> precompute(f, t_indicator[k]), change_metrics)
             # Loop over indicators
             for i in 1:n_ind
                 indicator = indicators[i]
-                chametric = one2one ? change_metrics[i] : change_metrics[1]
+                chametric = one2one ? precomp_change_metrics[k][i] :
+                    precomp_change_metrics[k][1]
                 z = view(x_indicator[k], :, i)
                 windowmap!(indicator, z, xseg;
                     width = config.width_ind, stride = config.stride_ind
                 )
-                if chametric isa PrecomputableFunction
-                    chametric = precompute(chametric, t_indicator[k])
-                end
                 x_change[k, i] = chametric(z)
             end
         end
     end
     # put everything together in the output type
-    return SegmentedWindowResults(t, x, t_indicator, x_indicator, t_change, x_change, config)
+    return SegmentedWindowResults(t, x, t_indicator, x_indicator, t_change, x_change,
+        config, i1, i2, precomp_change_metrics)
 end
 
-function segment(t, x, t1, t2)
-    i1, i2 = argmin(abs.(t .- t1)), argmin(abs.(t .- t2))
-    return t[i1:i2], x[i1:i2]
+function segment_time(t::AbstractVector, t1, t2)
+    i1 = [searchsortedfirst(t, tt) for tt in t1]
+    i2 = [searchsortedlast(t, tt) for tt in t2]
+    return i1, i2
 end
-
 
 """
     SegmentedWindowResults <: IndicatorsChangesResults
@@ -126,9 +137,12 @@ It has the following fields that the user may access
 - `t_change`, the time vector of the change metric.
 
 - `config::SegmentedWindowConfig`, what was used for the analysis.
+- `i1::Vector{Int}` indices corresponding to start time of each segment.
+- `i2::Vector{Int}` indices corresponding to end time of each segment.
+- `precomp_change_metrics` vector containing the precomputed change metrics of each segment.
 """
 struct SegmentedWindowResults{TT, T<:Real, X<:Real, XX<:AbstractVector{X},
-    W} <: IndicatorsChangesResults
+    W, Z} <: IndicatorsChangesResults
     t::TT # original time vector; most often it is `Base.OneTo`.
     x::XX
     t_indicator::Vector{Vector{T}}
@@ -136,6 +150,9 @@ struct SegmentedWindowResults{TT, T<:Real, X<:Real, XX<:AbstractVector{X},
     t_change::Vector{T}
     x_change::Matrix{X}
     config::W
+    i1::Vector{Int}
+    i2::Vector{Int}
+    precomp_change_metrics::Z
 end
 
 # Segmented and Sliding results share their show method

--- a/src/significance/surrogates_significance.jl
+++ b/src/significance/surrogates_significance.jl
@@ -58,127 +58,116 @@ function SurrogatesSignificance(;
 end
 
 function significant_transitions(res::SlidingWindowResults, signif::SurrogatesSignificance)
-    (; indicators, change_metrics) = res.config
-    tail = signif.tail
-    if !(tail isa Symbol) && length(tail) ≠ length(indicators)
-        throw(ArgumentError("Given `tail` must be a symbol or an iterable of same length "*
-        "as the input indicators. Got length $(length(tail)) instead of $(length(indicators))."
-        ))
-    end
-    pvalues = signif.pvalues = similar(res.x_change)
+    # Unpack structs + sanity check
+    (; x, x_indicator, x_change) = res
+    (; indicators, change_metrics, width_ind, stride_ind, width_cha, stride_cha) = res.config
+    (; surrogate, n, tail, rng, p, pvalues) = signif
+    n_ind = length(indicators)
+    sanitycheck_tail(tail, n_ind)
+    
+    # Init pvalues
+    X = eltype(x_change)
+    pvalues = signif.pvalues = zeros(X, size(x_change))
+    pvals_right = copy(pvalues)
+    pvals_left = copy(pvalues)
+
     # Multi-threaded surrogate realization
-    seeds = rand(signif.rng, 1:typemax(Int), Threads.nthreads())
-    sgens = [surrogenerator(res.x, signif.surrogate, Random.Xoshiro(seed)) for seed in seeds]
+    seeds = rand(rng, 1:typemax(Int), Threads.nthreads())
+    sgens = [surrogenerator(x, surrogate, Xoshiro(seed)) for seed in seeds]
     # Dummy vals for surrogate parallelization
-    indicator_dummys = [res.x_indicator[:, 1] for _ in 1:Threads.nthreads()]
-    change_dummys = [res.x_change[:, 1] for _ in 1:Threads.nthreads()]
-    for i in 1:size(pvalues, 2) # loop over change metrics
-        indicator = indicators[i]
-        i_metric = length(change_metrics) == length(indicators) ? i : 1
-        chametric = change_metrics[i_metric]
-        tai = tail isa Symbol ? tail : tail[i]
-        c = view(res.x_change, :, i) # change metric timeseries
-        # p values for current i
-        pval = view(pvalues, :, i)
-        sliding_surrogates_loop!(
-            indicator, chametric, c, pval, signif.n, sgens,
-            indicator_dummys, change_dummys,
-            res.config.width_ind, res.config.stride_ind, res.config.width_cha, res.config.stride_cha, tai
-        )
+    indicator_dummys = [x_indicator[:, 1] for _ in 1:Threads.nthreads()]
+    change_dummys = [x_change[:, 1] for _ in 1:Threads.nthreads()]
+
+    Threads.@threads for _ in 1:n
+
+        id = Threads.threadid()
+        s = sgens[id]()
+        change_dummy = change_dummys[id]
+
+        for i in 1:n_ind
+            indicator, change_metric, tai = choose_metrics(indicators, change_metrics,
+                tail, i)
+            c = view(x_change, :, i)    # change metric timeseries
+            pval_right = view(pvals_right, :, i)
+            pval_left = view(pvals_left, :, i)
+            windowmap!(indicator, indicator_dummys[id], s;
+                width = width_ind, stride = stride_ind)
+            windowmap!(change_metric, change_dummys[id], indicator_dummys[id];
+                width = width_cha, stride = stride_cha)
+            accumulate_pvals!(pval_right, pval_left, tai, c, change_dummy)
+        end
     end
-    pvalues ./= signif.n
-    return pvalues .< signif.p
+    choose_pval!(pvalues, pvals_right, pvals_left, tail, n_ind)
+    pvalues ./= n
+    return pvalues .< p
 end
 
 function significant_transitions(res::SegmentedWindowResults, signif::SurrogatesSignificance)
-    # Unpack and sanity checks
-    X = eltype(res.x_change)
-    (; indicators, change_metrics, tseg_start, tseg_end) = res.config
-    tail = signif.tail
-    if !(tail isa Symbol) && length(tail) ≠ length(indicators)
-        throw(ArgumentError("Given `tail` must be a symbol or an iterable of same length "*
-        "as the input indicators. Got length $(length(tail)) instead of $(length(indicators))."
-        ))
-    end
+    # Unpack structs + sanity check
+    (; x, t_indicator, x_change, i1, i2, precomp_change_metrics) = res
+    (; indicators, change_metrics, width_ind, stride_ind, min_width_cha) = res.config
+    (; surrogate, n, tail, rng, p) = signif
+    n_ind = length(indicators)
+    sanitycheck_tail(tail, n_ind)
+
+    # Init pvalues
+    X = eltype(x_change)
+    pvalues = signif.pvalues = zeros(X, size(x_change))
+    pvals_right = copy(pvalues)
+    pvals_left = copy(pvalues)
+
     # Multi-threaded surrogate realization
-    seeds = rand(signif.rng, 1:typemax(Int), Threads.nthreads())
-    change_dummys = [X(0) for _ in 1:Threads.nthreads()]
-    pvalues = signif.pvalues = zeros(X, size(res.x_change)...)
+    seeds = rand(rng, 1:typemax(Int), Threads.nthreads())
+    change_dummys = zeros(X, Threads.nthreads())
+    xind_length = map(x -> length(x), t_indicator)
+    indicator_dummys = Vector{X}[zeros(X, maximum(xind_length)) for _ in
+        1:Threads.nthreads()]
 
-    for k in eachindex(tseg_start)  # loop over segments
+    # Loop over segments
+    for k in eachindex(i1)
+
         # If segment too short, return inf p-value
-        if length(res.x_indicator[k][:, 1]) < res.config.min_width_cha
-            pvalues[k, :] .= Inf
+        if xind_length[k] < min_width_cha
+            view(pvalues, k, :) .= X(Inf)
         else
-            tseg, xseg = segment(res.t, res.x, tseg_start[k], tseg_end[k])
-            sgens = [surrogenerator(xseg, signif.surrogate, Random.Xoshiro(seed))
-                for seed in seeds]
-            # Dummy vals for surrogate parallelization
-            indicator_dummys = [res.x_indicator[k][:, 1] for _ in 1:Threads.nthreads()]
-            for i in eachindex(indicators)
-                indicator = indicators[i]
-                i_metric = length(change_metrics) == length(indicators) ? i : 1
-                chametric = change_metrics[i_metric]
+            # Generate surrogates of segment size
+            sgens = [surrogenerator(x[i1[k]:i2[k]], surrogate,
+                Random.Xoshiro(seed)) for seed in seeds]
 
-                # Precomputation: include time vector for metrics that require it!
-                if chametric isa PrecomputableFunction
-                    chametric = precompute(chametric, res.t_indicator[k])
+            Threads.@threads for _ in 1:n
+                id = Threads.threadid()
+                s = sgens[id]()
+                for i in eachindex(indicators)
+                    indicator, chametric, tai = choose_metrics(indicators,
+                        precomp_change_metrics[k], tail, i)
+                    c = x_change[k, i]
+                    indicator_dummy = view(indicator_dummys[id], 1:xind_length[k])
+                    windowmap!(indicator, indicator_dummy, s;
+                        width = width_ind, stride = stride_ind)
+                    change_dummys[id] = chametric(indicator_dummy)
+                    accumulate_pvals!(pvals_right, pvals_left, tai, c, change_dummys[id],
+                        k, i)
+                    choose_pval!(pvalues, pvals_right, pvals_left, tail, k, i)
                 end
-
-                tai = tail isa Symbol ? tail : tail[i]
-                c = res.x_change[k, i]  # change metric
-                pval = view(pvalues, k, i)
-                # p values for current i
-                segmented_surrogates_loop!(
-                    indicator, chametric, c, pval, signif.n, sgens,
-                    indicator_dummys, change_dummys,
-                    res.config.width_ind, res.config.stride_ind, tai)
             end
         end
     end
-    pvalues ./= signif.n
-    return pvalues .< signif.p
+    pvalues ./= n
+    return pvalues .< p
 end
 
-function sliding_surrogates_loop!(
-        indicator, chametric, c, pval, n_surrogates, sgens,
-        indicator_dummys, change_dummys,
-        width_ind, stride_ind, width_cha, stride_cha, tail
-    )
-    pval_right = zeros(length(pval))
-    pval_left = copy(pval_right)
-
-    # parallelized surrogate loop
-    Threads.@threads for _ in 1:n_surrogates
-        id = Threads.threadid()
-        s = sgens[id]()
-        change_dummy = change_dummys[id]
-        windowmap!(indicator, indicator_dummys[id], s;
-            width = width_ind, stride = stride_ind)
-        windowmap!(chametric, change_dummy, indicator_dummys[id];
-            width = width_cha, stride = stride_cha)
-        accumulate_pvals!(pval_right, pval_left, tail, c, change_dummy)
+function sanitycheck_tail(tail, n_ind)
+    if !(tail isa Symbol) && length(tail) ≠ n_ind
+        throw(ArgumentError("Given `tail` must be a symbol or an iterable of same length "*
+        "as the input indicators. Got length $(length(tail)) instead of $n_ind."
+        ))
     end
-    choose_pval!(pval, pval_right, pval_left, tail)
 end
 
-function segmented_surrogates_loop!(
-    indicator, chametric, c, pval, n_surrogates, sgens,
-    indicator_dummys, change_dummys, width_ind, stride_ind, tail
-)
-    pval_right = zeros(length(pval))
-    pval_left = copy(pval_right)
-    # parallelized surrogate loop
-    Threads.@threads for _ in 1:n_surrogates
-        id = Threads.threadid()
-        s = sgens[id]()
-        change_dummy = change_dummys[id]
-        windowmap!(indicator, indicator_dummys[id], s;
-            width = width_ind, stride = stride_ind)
-        change_dummy = chametric(indicator_dummys[id])
-        accumulate_pvals!(pval_right, pval_left, tail, c, change_dummy)
-    end
-    choose_pval!(pval, pval_right, pval_left, tail)
+function choose_metrics(indicators::Tuple{Vararg}, change_metrics, tail, i::Int)
+    i_metric = length(change_metrics) == length(indicators) ? i : 1
+    tai = tail isa Symbol ? tail : tail[i]
+    return indicators[i], change_metrics[i_metric], tai
 end
 
 function accumulate_pvals!(pval_right, pval_left, tail, c, change_dummy)
@@ -190,6 +179,26 @@ function accumulate_pvals!(pval_right, pval_left, tail, c, change_dummy)
     end
 end
 
+function accumulate_pvals!(pvals_right, pvals_left, tail, c, change_dummy, k, i)
+    if tail == :both || tail == :right
+        pvals_right[k, i] += c < change_dummy
+    end
+    if tail == :both || tail == :left
+        pvals_left[k, i] += c > change_dummy
+    end
+end
+
+# loop vectorial choose_pval! over indices
+function choose_pval!(pvals, pvals_right, pvals_left, tail, n_ind)
+    for i in 1:n_ind
+        pval = view(pvals, :, i)
+        pval_right = view(pvals_right, :, i)
+        pval_left = view(pvals_left, :, i)
+        choose_pval!(pval, pval_right, pval_left, tail)
+    end
+end
+
+# vectorial choose_pval!
 function choose_pval!(pval, pval_right, pval_left, tail)
     if tail == :both
         pval .= 2min.(pval_right, pval_left)
@@ -197,5 +206,16 @@ function choose_pval!(pval, pval_right, pval_left, tail)
         pval .= pval_right
     elseif tail == :left
         pval .= pval_left
+    end
+end
+
+# scalar choose_pval!
+function choose_pval!(pvals, pvals_right, pvals_left, tail, k, i)
+    if tail == :both
+        pvals[k, i] = 2min(pvals_right[k, i], pvals_left[k, i])
+    elseif tail == :right
+        pvals[k, i] = pvals_right[k, i]
+    elseif tail == :left
+        pvals[k, i] = pvals_left[k, i]
     end
 end

--- a/src/significance/surrogates_significance.jl
+++ b/src/significance/surrogates_significance.jl
@@ -126,9 +126,9 @@ function significant_transitions(res::SegmentedWindowResults, signif::Surrogates
     # Loop over segments
     for k in eachindex(i1)
 
-        # If segment too short, return inf p-value
+        # If segment too short, return NaN p-value
         if xind_length[k] < min_width_cha
-            view(pvalues, k, :) .= X(Inf)
+            view(pvalues, k, :) .= X(NaN)
         else
             # Generate surrogates of segment size
             sgens = [surrogenerator(x[i1[k]:i2[k]], surrogate,


### PR DESCRIPTION
Hi @Datseris,

This PR swaps the indicator and surrogate loops in `significant_transitions()`. This prevents us from generating more surrogates than needed, as discussed in #25. The computation time and memory allocation are improved and quantified in examples that you will find in `benchmarks/swapped_loops.jl`. Spoiler:

```julia
@btime significant_transitions($results, $signif)
#=
New code = swaploops-indicators-surrogates.
Old code = main branch (2023/10/30).

New code: 2.103 s (60,345 allocations: 1.12 GiB)
Old code: 2.413 s (80,415 allocations: 2.24 GiB)
=#
```

This is for the sliding analysis. For the segmented one:

```julia
@btime significant_transitions($results, $signif)
#=
New code = swaploops-indicators-surrogates.
Old code = main branch (2023/10/30).

New code: 3.024 s (202,536 allocations: 956.14 MiB)
Old code: 3.881 s (403,763 allocations: 1.87 GiB)
=#
```

See code for more details!

Swapping the loops makes the previously defined `sliding_surrogates_loop!()` and `sliding_surrogates_loop!()` obsolete. To ease the maintenance and readability of `significant_transitions()`, I introduced `sanitycheck_tail()` and `choose_metrics()`, and further dispatched `accumulate_pval!()` and `choose_pval!()` (not happy super happy with how I did it, but did not know how to do it better).

Furthermore, I took advantage to fix the suboptimal computation time of the segmented analysis by:
1. making better preallocations before the loops. 
2. fetching the indices corresponding to the beginning and end of the segments with `segment_time()` instead of the previously used (and suboptimal) `segment()`. The indices are passed to `SegmentedWindowResults` to avoid re-computing these indices in `significant_transitions()`.
3. precomputing the change metrics before the surrogate significance and storing them in `SegmentedWindowResults`. Note: this step is a bit tricky in a segmented analysis compared to a sliding one, since a precomputation is needed for each segment.
4. using views.

Note that, so far, `n` surrogates are generated **for each segment**. We were disagreeing a bit about this #25. Let's talk about it live and adapt if needed.

Finally, something for future PRs. I believe that precomputing all metrics (indicator and change) should be done in `estimate_indicator_changes()`. In fact, this depends on the time series that is passed, which is not done when defining the config.

I hope it's clear!