### PR TITLE
Fix `kendalltau` + fix `nothing` for `SegmentedWindowConfig`

### DIFF
--- a/src/analysis/segmented_window.jl
+++ b/src/analysis/segmented_window.jl
@@ -97,10 +97,16 @@ function estimate_indicator_changes(config::SegmentedWindowConfig, x, t)
                 chametric = one2one ? precomp_change_metrics[k][i] :
                     precomp_change_metrics[k][1]
                 z = view(x_indicator[k], :, i)
-                windowmap!(indicator, z, xseg;
-                    width = config.width_ind, stride = config.stride_ind
-                )
-                x_change[k, i] = chametric(z)
+                if isnothing(indicator)
+                    z = xseg[config.width_ind:config.stride_ind:end]
+                else
+                    windowmap!(indicator, z, xseg;
+                        width = config.width_ind, stride = config.stride_ind
+                    )
+                end
+                if !isnothing(chametric)
+                    x_change[k, i] = chametric(z)
+                end
             end
         end
     end

--- a/src/change_metrics/slope.jl
+++ b/src/change_metrics/slope.jl
@@ -9,7 +9,7 @@ using StatsBase: corkendall, corspearman
 Compute the kendall-τ correlation coefficient of the time series `x`.
 `kendalltau` can be used as a change metric focused on trend.
 """
-kendalltau(x) = corkendall(1:length(x), x)
+kendalltau(x) = corkendall(collect(1:length(x)), collect(x))
 
 """
     spearman(x::AbstractVector)


### PR DESCRIPTION
Two minor fixes:
- `kendalltau(x, y)` requires `x::Vector` and `y::Vector`. This was previously not enforced in our code and is now the case by the use of `collect()`
- Passing `nothing` as indicator was not handled in `segmentedWindowConfig`, which has been corrected.
