### PR TITLE
Minor fixes of typos, README and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,16 @@
 [![codecov](https://codecov.io/gh/JuliaDynamics/TransitionsInTimeseries.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/JuliaDynamics/TransitionsInTimeseries.jl)
 [![Package Downloads](https://shields.io/endpoint?url=https://pkgs.genieframework.com/api/v1/badge/TransitionsInTimeseries)](https://pkgs.genieframework.com?packages=TransitionsInTimeseries)
 
-A Julia package for estimating transitions (from one dynamic regime or stable state to another) in timeseries and testing the statistical significance of found transitions. It integrates with the entire Julia ecosystem of timeseries analysis, and hence offers thousands of metrics that can indicate transitions right out of the box. It also offers a variety of analysis pipelines for identifying transitions and a variety of statistical pipelines for testing for significance.
 
-In contrast to other existing software with similar target application, TransitionsInTimeseries.jl defines a generic interface for how to find transitions and how to test for significance. Within this interface, it is easy to expand the software in three orthogonal ways:
+TransitionsInTimeseries.jl is a free and open-source software to easily analyse transitions within timeseries in a reproducible, performant, extensible and reliable way. In contrast to other existing software with similar target application, TransitionsInTimeseries.jl defines a generic interface for how to find transitions and how to test for significance. Within this interface, it is easy to expand the software in three orthogonal ways:
 
-1. Add new indicators that work with the existing analysis pipelines for finding transitions
-2. Add new analysis pipelines for finding transitions
-3. Add new ways for testing whether already found transitions are significant
+1. Provide the analysis pipelines with new indicators, which can be either self-written or imported from other packages. In particular, the latter offers thousands of metrics that can indicate transitions right out of the box.
+2. Add new analysis pipelines for finding transitions.
+3. Add new ways for significance testing.
 
-This package is currently under active development and not yet registered in the Julia general registry. To install it, first go into package-manager mode in the Julia REPL (press `]`) and then run
+TransitionsInTimeseries is a registered Julia package and can be installed by running:
 ```
-add https://github.com/JuliaDynamics/TransitionsInTimeseries.jl
+] add TransitionsInTimeseries
 ```
 
 All further information is provided in the documentation, which you can either find [online](https://juliadynamics.github.io/TransitionsInTimeseries.jl/dev/) or build locally by running the `docs/make.jl` file.

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -1,5 +1,5 @@
 ---
-title: 'TransitionInTimeSeries.jl: A performant, extensible and reliable software for
+title: 'TransitionsInTimeseries.jl: A performant, extensible and reliable software for
 reproducible detection and prediction of transitions in timeseries'
 tags:
  - Julia

--- a/src/analysis/slope_change.jl
+++ b/src/analysis/slope_change.jl
@@ -38,7 +38,7 @@ function estimate_changes(config::ChangesConfig, x, t = eachindex(x))
             width = config.width_ind, stride = config.stride_ind
         )
     end
-    p0 = guess_initial_p(x, t)
+    p0 = guess_initial_p(x_indicator, t_indicator)
     fit = LsqFit.curve_fit(twolinear, t_indicator, x_indicator, p0)
     pbest = LsqFit.coef(fit)
     a, b, c, d = pbest

--- a/src/significance/slope_significance.jl
+++ b/src/significance/slope_significance.jl
@@ -28,6 +28,6 @@ function significant_transitions(res::SlopeChangeResults, signif::SlopeChangeSig
         moe[2] ≤ signif.moe_slope &&
         moe[4] ≤ signif.moe_slope)
 
-    slopeflag = abs(res.fitparams[2] - res.fitparams[4]) > moe_slope
+    slopeflag = abs(res.fitparams[2] - res.fitparams[4]) > signif.slope_diff
     return [moeflag && slopeflag]
 end

--- a/test/change_metrics.jl
+++ b/test/change_metrics.jl
@@ -3,7 +3,7 @@ using TransitionsInTimeseries, Test, Random, Distributions
 @testset "ridge regression" begin
     d = Normal()                            # define normal distribution
     m, p = 10 .* rand(Xoshiro(124), d, 2)   # slope and offset parameters
-    t = 0:0.1:100
+    t = 0:1:100
     x = m .* t .+ p
     x_noisy = x + 0.1 .* rand(d, length(x))
 
@@ -12,11 +12,19 @@ using TransitionsInTimeseries, Test, Random, Distributions
     m_hat_noisy = rr(x_noisy)
     @test isapprox(m_hat, m, atol = 1e-5)
     @test isapprox(m_hat_noisy, m, atol = 1e-2)
+
+    rr = RidgeRegressionSlope()
+    m_hat = rr(x)
+    m_hat_noisy = rr(x_noisy)
+    @test isapprox(m_hat, m, atol = 1e-5)
+    @test isapprox(m_hat_noisy, m, atol = 1e-2)
 end
 
 @testset "correlations" begin
-    x = 0:0.01:2π
-    y = sin.(x)
+    x = collect(1:5)
+    y = [1, 2, 3, 5, 4]
     @test spearman(x) == 1
-    # TODO: expand this when kendalltau fixed
+    @test kendalltau(x) == 1
+    @test isapprox(spearman(y), cov(x, y) / (std(x) * std(y)))
+    @test kendalltau(y) == 0.8
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,4 +9,5 @@ testfile(file, testname=defaultname(file)) = @testset "$testname" begin; include
     testfile("indicators.jl")
     testfile("change_metrics.jl")
     testfile("full_analysis.jl")
+    testfile("slope_change.jl")
 end


### PR DESCRIPTION
This PR:
- fixes the typos we had in the title of `paper.md`.
- provides an updated version of the README (with the correct installation information) and a description that is more coherent with the paper.
- the tests written for the `slope_change.jl` pipeline have been included in `runtests.jl` (a reason why our code coverage was lower than expected).
- (minor) additional tests for the change metrics.