### PR TITLE
minor heading fix: simpler -> simple

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TransitionsInTimeseries"
 uuid = "5f5b98ec-1183-43e0-887a-12fdc55c52f7"
 authors = ["Jan Swierczek-Jereczek <jan.jereczek@gmail.com>", "George Datseris <datseris.george@gmail.com>"]
-version = "0.1.3"
+version = "0.1.4"
 
 [deps]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"

--- a/docs/src/examples/logistic.jl
+++ b/docs/src/examples/logistic.jl
@@ -43,7 +43,7 @@ fig
 # to weak chaos at r ≈ 3.847. This transition is barely visible in the
 # timeseries, and in fact many of the timeseries statistical properties remain identical.
 
-# ## Using a simpler change metric
+# ## Using a simple change metric
 
 # Now, let's compute various indicators and their changes,
 # focusing on the permutation entropy as an indicator. We use


### PR DESCRIPTION
The first heading of using change metrics says "Using a simpler" change metric, which was a bit confusing to me as it is the first that is introduced. I assume this is either a typo or left from some previous revision where it's not the first.